### PR TITLE
Fix SmartFilter modal dismissal and check search handling

### DIFF
--- a/module/SmartFilter/SmartFilterController.cs
+++ b/module/SmartFilter/SmartFilterController.cs
@@ -51,6 +51,20 @@ namespace SmartFilter
         {
             try
             {
+                bool checkSearch = HttpContext.Request.Query.ContainsKey("checksearch");
+
+                if (checkSearch)
+                {
+                    var responseObject = new JObject
+                    {
+                        ["type"] = ResolveContentType(serial),
+                        ["title"] = title ?? original_title ?? string.Empty,
+                        ["year"] = year
+                    };
+
+                    return Content(responseObject.ToString(Formatting.None), "application/json; charset=utf-8");
+                }
+
                 HttpContext.Response.Headers["X-Timeout"] = "300000";
 
                 var querySnapshot = BuildQueryDictionary(HttpContext.Request.Query);
@@ -143,5 +157,15 @@ namespace SmartFilter
         }
 
         private bool IsAjaxRequest => HttpContext.Request.Headers["X-Requested-With"] == "XMLHttpRequest";
+
+        private static string ResolveContentType(int serial)
+        {
+            return serial switch
+            {
+                1 => "season",
+                2 => "episode",
+                _ => "movie"
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the SmartFilter modal wires close handlers for the close button, remote back key presses, and controller navigation
- clean up modal listeners when closing and integrate with the Lampa controller to restore focus
- return a lightweight response for checksearch requests so the SmartFilter provider passes Lampac availability checks

## Testing
- dotnet build module/SmartFilter/SmartFilter.csproj *(fails: dotnet not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e661ba644083318757065bf51abaaf