### PR TITLE
Add results alias to SmartFilter JSON output

### DIFF
--- a/module/SmartFilter/SmartFilterController.cs
+++ b/module/SmartFilter/SmartFilterController.cs
@@ -103,6 +103,7 @@ namespace SmartFilter
                     {
                         ["type"] = aggregation.Type,
                         ["data"] = aggregation.Data,
+                        ["results"] = aggregation.Data,
                         ["providers"] = JArray.FromObject(providerStatus),
                         ["progressKey"] = progressKey
                     };


### PR DESCRIPTION
## Summary
- include the aggregated payload under both `data` and `results` keys in the SmartFilter JSON response so consumers expecting either field can access the results

## Testing
- not run (dotnet CLI unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e66a88dbd483318ad2edaa0c4f9c5f