### PR TITLE
Improve season handling in SmartFilter

### DIFF
--- a/module/SmartFilter/ResponseRenderer.cs
+++ b/module/SmartFilter/ResponseRenderer.cs
@@ -104,6 +104,11 @@ namespace SmartFilter
                     continue;
 
                 string name = token.Value<string>("name") ?? token.Value<string>("title") ?? "Сезон";
+                string provider = token.Value<string>("provider") ?? token.Value<string>("balanser");
+
+                if (!string.IsNullOrWhiteSpace(provider) && !name.Contains(provider, StringComparison.OrdinalIgnoreCase))
+                    name = $"{provider} - {name}";
+
                 var dataObj = new JObject
                 {
                     ["method"] = "link",


### PR DESCRIPTION
## Summary
- allow anime-oriented providers to stay enabled when the incoming request does not explicitly mark the title as a film
- refine SmartFilter content-type resolution so serial requests prefer season/episode payloads
- surface provider names inside rendered season tiles for clearer grouping in Lampa

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6799854308331bc1d71eccaba53f3