### PR TITLE
Group SmartFilter season results by provider

### DIFF
--- a/module/SmartFilter/AggregationModels.cs
+++ b/module/SmartFilter/AggregationModels.cs
@@ -38,7 +38,7 @@ namespace SmartFilter
     public class AggregationResult
     {
         public string Type { get; set; }
-        public JArray Data { get; set; } = new JArray();
+        public JToken Data { get; set; }
         public List<ProviderStatus> Providers { get; set; } = new List<ProviderStatus>();
         public string ProgressKey { get; set; }
     }

--- a/module/SmartFilter/SmartFilterController.cs
+++ b/module/SmartFilter/SmartFilterController.cs
@@ -82,7 +82,7 @@ namespace SmartFilter
 
                 SmartFilterProgress.PublishFinal(memoryCache, progressKey, aggregation.Providers);
 
-                if (aggregation.Data == null || aggregation.Data.Count == 0)
+                if (IsEmpty(aggregation.Data))
                     return OnError("Контент не найден");
 
                 var providerStatus = aggregation.Providers
@@ -158,6 +158,28 @@ namespace SmartFilter
         }
 
         private bool IsAjaxRequest => HttpContext.Request.Headers["X-Requested-With"] == "XMLHttpRequest";
+
+        private static bool IsEmpty(JToken token)
+        {
+            if (token == null)
+                return true;
+
+            if (token is JArray array)
+                return array.Count == 0;
+
+            if (token is JObject obj)
+            {
+                foreach (var property in obj.Properties())
+                {
+                    if (property.Value is JArray nested && nested.Count > 0)
+                        return false;
+                }
+
+                return !obj.Properties().Any();
+            }
+
+            return !token.HasValues;
+        }
 
         private static string ResolveContentType(int serial)
         {


### PR DESCRIPTION
## Summary
- group provider payloads for season requests and emit grouped season markup
- update the aggregation model and controller to work with grouped `JToken` data and guard against empty responses
- enhance the SmartFilter plugin to flatten grouped JSON, toggle provider folders, and keep voice/quality filters working

## Testing
- `dotnet build module/SmartFilter/SmartFilter.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e67e516b34833185b28ca7511d3935