### PR TITLE
Fix SmartFilter season rendering and metadata

### DIFF
--- a/wwwroot/plugins/smartfilter.js
+++ b/wwwroot/plugins/smartfilter.js
@@ -358,6 +358,12 @@
                     cursor: pointer;
                 }
 
+                .smartfilter-meta {
+                    margin-top: 4px;
+                    font-size: 0.85em;
+                    color: rgba(255, 255, 255, 0.7);
+                }
+
                 .smartfilter-modal {
                     position: fixed;
                     top: 0;


### PR DESCRIPTION
## Summary
- improve SmartFilter aggregation to extract nested season and episode payloads and count provider items accurately
- render provider, translation, and quality metadata for seasons and episodes so they are ready to play and clearly labeled
- add styling for the metadata rows in the SmartFilter front-end

## Testing
- not run (dotnet CLI is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e688a5ea7c8331a5f1afe85c76f8c6