### PR TITLE
Fix SmartFilter season payload structure

### DIFF
--- a/module/SmartFilter/SmartFilterEngine.cs
+++ b/module/SmartFilter/SmartFilterEngine.cs
@@ -367,7 +367,7 @@ namespace SmartFilter
                 return "Источник";
             }
 
-            bool groupByProvider = string.Equals(expectedType, "season", StringComparison.OrdinalIgnoreCase);
+            bool groupByProvider = false;
 
             if (!groupByProvider)
             {


### PR DESCRIPTION
## Summary
- return a flat season array from SmartFilter so Lampa can parse responses correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e68d58c27c8331b3ad0245df875879