### PR TITLE
Add identifiers to smart filter provider list

### DIFF
--- a/module/SmartFilter/SmartFilterEngine.cs
+++ b/module/SmartFilter/SmartFilterEngine.cs
@@ -476,11 +476,17 @@ namespace SmartFilter
 
                 var item = new JObject
                 {
+                    ["id"] = result.ProviderIndex ?? list.Count + 1,
                     ["method"] = "link",
                     ["url"] = url,
                     ["title"] = providerName,
                     ["provider"] = providerName
                 };
+
+                if (baseQuery.TryGetValue("year", out var yearValue) && int.TryParse(yearValue, out var parsedYear))
+                    item["year"] = parsedYear;
+                else
+                    item["year"] = 0;
 
                 string details = BuildProviderDetails(result);
                 if (!string.IsNullOrWhiteSpace(details))


### PR DESCRIPTION
## Summary
- include a stable id for each provider entry returned in the similar response
- propagate the title year (or 0 fallback) with provider links so Lampa parsing succeeds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e695f7262083319e7652e4f99e92ad