### PR TITLE
Fix episode HTML generation to include voices

### DIFF
--- a/module/SmartFilter/SmartFilterEngine.cs
+++ b/module/SmartFilter/SmartFilterEngine.cs
@@ -759,7 +759,7 @@ namespace SmartFilter
             if (!string.IsNullOrWhiteSpace(quality) && json is JObject obj)
                 obj["maxquality"] = quality;
 
-            var html = episodeTpl.ToHtml(voiceTemplate);
+            var html = BuildEpisodeHtml(episodeTpl, voiceTemplate);
             return new AggregatedPayload(json, html);
         }
 
@@ -775,7 +775,7 @@ namespace SmartFilter
                 if (!string.IsNullOrWhiteSpace(quality) && json is JObject obj)
                     obj["maxquality"] = quality;
 
-                var html = tpl.ToHtml(voiceTpl);
+                var html = BuildEpisodeHtml(tpl, voiceTpl);
                 return new AggregatedPayload(json, html);
             }
 
@@ -819,6 +819,20 @@ namespace SmartFilter
             }
 
             return tpl;
+        }
+
+        private static string BuildEpisodeHtml(EpisodeTpl episodeTpl, VoiceTpl? voiceTpl)
+        {
+            string episodeHtml = episodeTpl?.ToHtml() ?? string.Empty;
+            string voiceHtml = voiceTpl?.ToHtml() ?? string.Empty;
+
+            if (string.IsNullOrEmpty(voiceHtml))
+                return episodeHtml;
+
+            if (string.IsNullOrEmpty(episodeHtml))
+                return voiceHtml;
+
+            return voiceHtml + episodeHtml;
         }
 
         private static string CombineNameWithProvider(string baseName, string provider)


### PR DESCRIPTION
## Summary
- concatenate voice template HTML with episode template HTML instead of calling a non-existent overload
- share the episode HTML assembly logic between populated and empty episode payloads

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c97d04448331a60eb6a9ff8af336