### PR TITLE
Fix SmartFilter ResponseRenderer array naming conflict

### DIFF
--- a/module/SmartFilter/ResponseRenderer.cs
+++ b/module/SmartFilter/ResponseRenderer.cs
@@ -39,9 +39,9 @@ namespace SmartFilter
                     episodeData = container["episodes"] as JArray;
                     groupedSeasons = container["groupedSeasons"] as JObject;
                 }
-                else if (seriesData is JArray array)
+                else if (seriesData is JArray seriesArray)
                 {
-                    seasonData = array;
+                    seasonData = seriesArray;
                 }
             }
 
@@ -70,15 +70,15 @@ namespace SmartFilter
                 data = Flatten(grouped);
             }
 
-            if (data is not JArray array || array.Count == 0)
+            if (data is not JArray items || items.Count == 0)
                 return voiceHtml ?? string.Empty;
 
             string content = type switch
             {
-                "similar" => BuildSimilarHtml(array),
-                "season" => BuildSeasonHtml(array, maxQuality),
-                "episode" => BuildEpisodeHtml(array),
-                _ => BuildMovieHtml(array, title, originalTitle)
+                "similar" => BuildSimilarHtml(items),
+                "season" => BuildSeasonHtml(items, maxQuality),
+                "episode" => BuildEpisodeHtml(items),
+                _ => BuildMovieHtml(items, title, originalTitle)
             };
 
             if (string.IsNullOrEmpty(content))


### PR DESCRIPTION
## Summary
- rename conflicting pattern-matching variables in `ResponseRenderer` to avoid scope clashes
- ensure the chosen JArray instance is reused when building HTML content

## Testing
- dotnet build module/SmartFilter/SmartFilter.csproj *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea5935b3b08331b3ddc70b61b38939