### PR TITLE
Fix SmartFilter metadata cloning and progress readiness

### DIFF
--- a/module/SmartFilter/AggregationModels.cs
+++ b/module/SmartFilter/AggregationModels.cs
@@ -57,11 +57,24 @@ namespace SmartFilter
             return new AggregationMetadata
             {
                 TotalItems = TotalItems,
-                Qualities = Qualities?.ToDictionary(k => k.Key, v => v.Value.Clone(), StringComparer.OrdinalIgnoreCase)
-                    ?? new Dictionary<string, AggregationFacet>(StringComparer.OrdinalIgnoreCase),
-                Voices = Voices?.ToDictionary(k => k.Key, v => v.Value.Clone(), StringComparer.OrdinalIgnoreCase)
-                    ?? new Dictionary<string, AggregationFacet>(StringComparer.OrdinalIgnoreCase)
+                Qualities = CloneFacets(Qualities),
+                Voices = CloneFacets(Voices)
             };
+        }
+
+        private static Dictionary<string, AggregationFacet> CloneFacets(Dictionary<string, AggregationFacet> source)
+        {
+            var cloned = new Dictionary<string, AggregationFacet>(StringComparer.OrdinalIgnoreCase);
+
+            if (source == null)
+                return cloned;
+
+            foreach (var pair in source)
+            {
+                cloned[pair.Key] = pair.Value?.Clone();
+            }
+
+            return cloned;
         }
     }
 

--- a/module/SmartFilter/SmartFilterProgress.cs
+++ b/module/SmartFilter/SmartFilterProgress.cs
@@ -76,7 +76,7 @@ namespace SmartFilter
                 state.Partial = partial != null ? (JArray)partial.DeepClone() : null;
                 state.Metadata = metadata?.Clone();
                 if (ready)
-                    state.Ready = true;
+                    state.MarkReady();
 
                 cache.Set(progressKey, state, ProgressTtl);
             }
@@ -169,6 +169,11 @@ namespace SmartFilter
                     Partial = (JArray)partial.DeepClone();
                 if (metadata != null)
                     Metadata = metadata.Clone();
+            }
+
+            public void MarkReady()
+            {
+                Ready = true;
             }
 
             public ProgressSnapshot ToSnapshot()


### PR DESCRIPTION
## Summary
- clone aggregation metadata facets without relying on unavailable ToDictionary overloads
- expose a controlled way to mark progress state as ready when partial results finish

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ead1a3bf988331b093a5af9003ebb5