### PR TITLE
Align SmartFilter engine with controller parameters

### DIFF
--- a/module/SmartFilter/SmartFilterController.cs
+++ b/module/SmartFilter/SmartFilterController.cs
@@ -187,7 +187,7 @@ namespace SmartFilter
                         serialCacheKey,
                         serialTtl,
                         proxyManager: null,
-                        async res =>
+                        res =>
                         {
                             var sr = GetSerials.Process(
                                 validResults,
@@ -199,9 +199,9 @@ namespace SmartFilter
                             );
 
                             if (sr == null || (sr.SeasonCount == 0 && sr.EpisodeCount == 0))
-                                return res.Fail("no content");
+                                return new ValueTask<dynamic>((dynamic)res.Fail("no content"));
 
-                            return sr;
+                            return new ValueTask<dynamic>(sr);
                         }
                     );
 


### PR DESCRIPTION
## Summary
- accept the full SmartFilter controller argument set in AggregateProvidersAsync and propagate them to /lite/events and provider requests
- record provider status metadata consistently, including success flags and the resolved request URL
- eliminate the redundant async lambda in SmartFilterController by returning ValueTask directly

## Testing
- dotnet build *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebe10628148331b826aff7a060db40