### PR TITLE
Improve series aggregation output for SmartFilter

### DIFF
--- a/module/SmartFilter/ResponseRenderer.cs
+++ b/module/SmartFilter/ResponseRenderer.cs
@@ -23,12 +23,12 @@ namespace SmartFilter
 
             if (isSeason || isEpisode)
             {
-                var (seriesData, voiceData, quality) = SeriesDataHelper.Unpack(data);
-                data = seriesData;
-                maxQuality = quality;
+                var seriesPayload = SeriesDataHelper.Extract(type, data);
+                data = seriesPayload.Items;
+                maxQuality = seriesPayload.MaxQuality;
 
-                if (voiceData != null && voiceData.Count > 0)
-                    voiceHtml = BuildVoiceHtml(voiceData);
+                if (seriesPayload.Voice != null && seriesPayload.Voice.Count > 0)
+                    voiceHtml = BuildVoiceHtml(seriesPayload.Voice);
             }
 
             if (data is JObject grouped)

--- a/module/SmartFilter/SeriesDataHelper.cs
+++ b/module/SmartFilter/SeriesDataHelper.cs
@@ -1,23 +1,357 @@
 using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace SmartFilter
 {
     internal static class SeriesDataHelper
     {
-        public static (JArray Data, JArray Voice, string MaxQuality) Unpack(JToken payload)
+        internal sealed class SeriesDataPayload
+        {
+            public SeriesDataPayload(JArray items, JArray voice, string maxQuality, JToken original, JObject container, JObject metadata)
+            {
+                Items = items ?? new JArray();
+                Voice = voice;
+                MaxQuality = maxQuality;
+                Original = original;
+                Container = container;
+                Metadata = metadata;
+            }
+
+            public JArray Items { get; }
+            public JArray Voice { get; }
+            public string MaxQuality { get; }
+            public JToken Original { get; }
+            public JObject Container { get; }
+            public JObject Metadata { get; }
+        }
+
+        public static SeriesDataPayload Extract(string type, JToken payload)
+        {
+            var clone = payload?.DeepClone();
+            var voice = ExtractVoice(clone);
+            var maxQuality = ExtractQuality(clone);
+            var items = ExtractItems(clone);
+
+            if (string.IsNullOrWhiteSpace(maxQuality) && items != null)
+            {
+                maxQuality = items
+                    .OfType<JObject>()
+                    .Select(i => i.Value<string>("maxquality") ?? i.Value<string>("quality"))
+                    .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+            }
+            var container = BuildContainer(type, clone, items, voice, maxQuality);
+            var metadata = BuildMetadata(items, voice, maxQuality);
+
+            return new SeriesDataPayload(items, voice, maxQuality, clone, container, metadata);
+        }
+
+        private static JArray ExtractItems(JToken payload)
         {
             if (payload is JObject obj)
             {
-                var data = obj["data"] as JArray ?? new JArray();
-                var voice = obj["voice"] as JArray;
-                if (voice != null && voice.Count == 0)
-                    voice = null;
+                if (TryExtractArray(obj, "data", out var fromData))
+                    return fromData;
 
-                string quality = obj.Value<string>("maxquality") ?? obj.Value<string>("quality");
-                return (data, voice, quality);
+                if (TryExtractArray(obj, "results", out var fromResults))
+                    return fromResults;
+
+                if (TryExtractArray(obj, "episodes", out var fromEpisodes))
+                    return fromEpisodes;
+
+                if (TryExtractArray(obj, "seasons", out var fromSeasons))
+                    return fromSeasons;
+
+                var aggregated = new JArray();
+                foreach (var property in obj.Properties())
+                {
+                    if (property.Value == null || property.Value.Type == JTokenType.Null)
+                        continue;
+
+                    foreach (var item in EnumerateItems(property.Value))
+                        aggregated.Add(item.DeepClone());
+                }
+
+                return aggregated;
             }
 
-            return (payload as JArray ?? new JArray(), null, null);
+            if (payload is JArray array)
+                return (JArray)array.DeepClone();
+
+            return new JArray();
+        }
+
+        private static bool TryExtractArray(JObject obj, string key, out JArray result)
+        {
+            result = null;
+            if (obj == null || string.IsNullOrWhiteSpace(key))
+                return false;
+
+            if (!obj.TryGetValue(key, out var token) || token == null || token.Type == JTokenType.Null)
+                return false;
+
+            if (token is JArray array)
+            {
+                if (array.Count == 0)
+                    return false;
+
+                result = (JArray)array.DeepClone();
+                return true;
+            }
+
+            if (token is JObject nested)
+            {
+                var aggregated = new JArray();
+                foreach (var property in nested.Properties())
+                {
+                    if (property.Value is JArray propertyArray)
+                    {
+                        foreach (var item in propertyArray)
+                            aggregated.Add(item.DeepClone());
+                    }
+                    else if (property.Value is JObject propertyObject)
+                    {
+                        aggregated.Add(propertyObject.DeepClone());
+                    }
+                }
+
+                if (aggregated.Count > 0)
+                {
+                    result = aggregated;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<JToken> EnumerateItems(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+                yield break;
+
+            if (token is JArray array)
+            {
+                foreach (var item in array)
+                    yield return item;
+
+                yield break;
+            }
+
+            if (token is JObject obj)
+            {
+                foreach (var property in obj.Properties())
+                {
+                    foreach (var item in EnumerateItems(property.Value))
+                        yield return item;
+                }
+            }
+        }
+
+        private static JArray ExtractVoice(JToken payload)
+        {
+            if (payload is not JObject obj)
+                return null;
+
+            var voiceToken = obj["voice"] ?? obj["voices"] ?? obj["voice_list"] ?? obj["translations"];
+            if (voiceToken is JArray voiceArray && voiceArray.Count > 0)
+                return (JArray)voiceArray.DeepClone();
+
+            return null;
+        }
+
+        private static string ExtractQuality(JToken payload)
+        {
+            if (payload is not JObject obj)
+                return null;
+
+            foreach (var property in obj.Properties())
+            {
+                if (!string.Equals(property.Name, "maxquality", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(property.Name, "quality", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                string value = property.Value?.ToString();
+                if (!string.IsNullOrWhiteSpace(value))
+                    return value;
+            }
+
+            return null;
+        }
+
+        private static JObject BuildContainer(string type, JToken payload, JArray items, JArray voice, string maxQuality)
+        {
+            var container = payload as JObject ?? new JObject();
+
+            if (!string.IsNullOrWhiteSpace(type))
+                container["type"] = type;
+
+            if (voice != null)
+                container["voice"] = voice.DeepClone();
+
+            if (!string.IsNullOrWhiteSpace(maxQuality))
+                container["maxquality"] = maxQuality;
+
+            if (items != null && items.Count > 0)
+            {
+                if (string.Equals(type, "episode", StringComparison.OrdinalIgnoreCase))
+                    container["episodes"] = items.DeepClone();
+                else
+                    container["seasons"] = items.DeepClone();
+            }
+
+            var grouped = ExtractGroupedSeasons(container);
+            if (grouped != null)
+                container["groupedSeasons"] = grouped;
+
+            return container;
+        }
+
+        private static JObject ExtractGroupedSeasons(JObject container)
+        {
+            if (container == null)
+                return null;
+
+            foreach (var key in new[] { "providers", "grouped", "playlists" })
+            {
+                if (!container.TryGetValue(key, out var token) || token is not JObject obj || !obj.Properties().Any())
+                    continue;
+
+                var grouped = new JObject();
+                foreach (var property in obj.Properties())
+                {
+                    if (property.Value is JArray array && array.Count > 0)
+                        grouped[property.Name] = array.DeepClone();
+                }
+
+                if (grouped.Properties().Any())
+                    return grouped;
+            }
+
+            return null;
+        }
+
+        private static JObject BuildMetadata(JArray items, JArray voice, string maxQuality)
+        {
+            var metadata = new JObject();
+
+            var voicesMap = new JObject();
+            foreach (var label in CollectVoiceLabels(items, voice))
+            {
+                var key = NormalizeKey(label);
+                if (!voicesMap.TryGetValue(key, out var existing) || existing is not JObject entry)
+                {
+                    entry = new JObject
+                    {
+                        ["label"] = label,
+                        ["count"] = 0
+                    };
+                    voicesMap[key] = entry;
+                }
+
+                entry["count"] = entry.Value<int>("count") + 1;
+            }
+
+            if (voicesMap.Properties().Any())
+                metadata["voices"] = voicesMap;
+
+            var qualityMap = new JObject();
+            foreach (var label in CollectQualityLabels(items, maxQuality))
+            {
+                var key = NormalizeKey(label);
+                if (!qualityMap.TryGetValue(key, out var existing) || existing is not JObject entry)
+                {
+                    entry = new JObject
+                    {
+                        ["label"] = label,
+                        ["count"] = 0
+                    };
+                    qualityMap[key] = entry;
+                }
+
+                entry["count"] = entry.Value<int>("count") + 1;
+            }
+
+            if (qualityMap.Properties().Any())
+                metadata["qualities"] = qualityMap;
+
+            return metadata.HasValues ? metadata : null;
+        }
+
+        private static IEnumerable<string> CollectVoiceLabels(JArray items, JArray voice)
+        {
+            var labels = new List<string>();
+
+            if (voice != null)
+            {
+                foreach (var token in voice.OfType<JObject>())
+                {
+                    string label = token.Value<string>("name") ?? token.Value<string>("title") ?? token.Value<string>("voice") ?? token.Value<string>("translation");
+                    if (!string.IsNullOrWhiteSpace(label))
+                        labels.Add(label);
+                }
+            }
+
+            if (items != null)
+            {
+                foreach (var token in items.OfType<JObject>())
+                {
+                    string label = token.Value<string>("voice") ??
+                                   token.Value<string>("voice_name") ??
+                                   token.Value<string>("translate") ??
+                                   token.Value<string>("details");
+
+                    if (!string.IsNullOrWhiteSpace(label))
+                        labels.Add(label);
+                }
+            }
+
+            return labels;
+        }
+
+        private static IEnumerable<string> CollectQualityLabels(JArray items, string maxQuality)
+        {
+            var labels = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(maxQuality))
+                labels.Add(maxQuality);
+
+            if (items != null)
+            {
+                foreach (var token in items.OfType<JObject>())
+                {
+                    string label = token.Value<string>("maxquality") ?? token.Value<string>("quality");
+                    if (!string.IsNullOrWhiteSpace(label))
+                        labels.Add(label);
+                }
+            }
+
+            return labels;
+        }
+
+        private static string NormalizeKey(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            var builder = new StringBuilder();
+            foreach (var ch in value.Trim().ToLowerInvariant())
+            {
+                if (char.IsLetterOrDigit(ch))
+                {
+                    builder.Append(ch);
+                }
+                else if (char.IsWhiteSpace(ch) || ch == '-' || ch == '_' || ch == '.')
+                {
+                    builder.Append('_');
+                }
+            }
+
+            return builder.Length > 0 ? builder.ToString() : value.Trim().ToLowerInvariant();
         }
     }
 }

--- a/module/SmartFilter/SmartFilterController.cs
+++ b/module/SmartFilter/SmartFilterController.cs
@@ -114,15 +114,22 @@ namespace SmartFilter
 
                     if (isSeries)
                     {
-                        var (seriesData, voiceData, quality) = SeriesDataHelper.Unpack(aggregation.Data);
-                        responseObject["data"] = seriesData.DeepClone();
-                        responseObject["results"] = seriesData.DeepClone();
+                        var seriesPayload = SeriesDataHelper.Extract(aggregation.Type, aggregation.Data);
+                        responseObject["data"] = seriesPayload.Items.DeepClone();
 
-                        if (voiceData != null)
-                            responseObject["voice"] = voiceData.DeepClone();
+                        var seriesResults = seriesPayload.Container != null && seriesPayload.Container.HasValues
+                            ? (JToken)seriesPayload.Container
+                            : seriesPayload.Items;
+                        responseObject["results"] = seriesResults.DeepClone();
 
-                        if (!string.IsNullOrWhiteSpace(quality))
-                            responseObject["maxquality"] = quality;
+                        if (seriesPayload.Voice != null)
+                            responseObject["voice"] = seriesPayload.Voice.DeepClone();
+
+                        if (!string.IsNullOrWhiteSpace(seriesPayload.MaxQuality))
+                            responseObject["maxquality"] = seriesPayload.MaxQuality;
+
+                        if (seriesPayload.Metadata != null)
+                            responseObject["metadata"] = seriesPayload.Metadata.DeepClone();
                     }
                     else
                     {


### PR DESCRIPTION
## Summary
- normalize season and episode payloads through a richer SeriesDataHelper extraction step
- expose series metadata and normalized structures in SmartFilterController JSON replies
- reuse the normalized data set when rendering HTML to guarantee voice and quality handling

## Testing
- `dotnet build module/SmartFilter/SmartFilter.csproj` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfbee28248331a57f39361d16865e