### PR TITLE
Добавить фильтрацию фильмов по озвучке и качеству

### DIFF
--- a/module/SmartFilter/ResponseRenderer.cs
+++ b/module/SmartFilter/ResponseRenderer.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.WebUtilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Shared.Models.Templates;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +13,28 @@ namespace SmartFilter
 {
     internal static class ResponseRenderer
     {
-        public static string BuildHtml(string type, JToken data, string title, string originalTitle)
+        internal sealed class MovieRenderPayload
+        {
+            public MovieRenderPayload(JArray items, string filtersHtml, bool hasActiveFilters)
+            {
+                Items = items ?? new JArray();
+                FiltersHtml = string.IsNullOrEmpty(filtersHtml) ? null : filtersHtml;
+                HasActiveFilters = hasActiveFilters;
+            }
+
+            public JArray Items { get; }
+            public string FiltersHtml { get; }
+            public bool HasActiveFilters { get; }
+        }
+
+        public static string BuildHtml(
+            string type,
+            JToken data,
+            string title,
+            string originalTitle,
+            string host = null,
+            IReadOnlyDictionary<string, string> query = null,
+            MovieRenderPayload moviePayload = null)
         {
             if (data == null)
                 return string.Empty;
@@ -30,6 +53,23 @@ namespace SmartFilter
 
                 if (seriesPayload.Voice != null && seriesPayload.Voice.Count > 0)
                     voiceHtml = BuildVoiceHtml(seriesPayload.Voice);
+            }
+
+            if (!isSeason && !isEpisode)
+            {
+                moviePayload ??= PrepareMoviePayload(data, query, host);
+
+                if (moviePayload != null)
+                {
+                    data = moviePayload.Items ?? data;
+
+                    if (!string.IsNullOrEmpty(moviePayload.FiltersHtml))
+                    {
+                        voiceHtml = string.IsNullOrEmpty(voiceHtml)
+                            ? moviePayload.FiltersHtml
+                            : string.Concat(voiceHtml, moviePayload.FiltersHtml);
+                    }
+                }
             }
 
             if (data is JObject grouped)
@@ -128,6 +168,539 @@ namespace SmartFilter
             }
 
             return flattened;
+        }
+
+        private static readonly string[] MovieVoiceKeys =
+        {
+            "smartfilterVoice",
+            "translation_key",
+            "translationKey",
+            "translation_id",
+            "translationId",
+            "voice_id",
+            "voiceId",
+            "voice",
+            "voice_name",
+            "voiceName",
+            "translate",
+            "translation",
+            "dub"
+        };
+
+        private static readonly string[] MovieQualityKeys =
+        {
+            "smartfilterQuality",
+            "maxquality",
+            "maxQuality",
+            "quality",
+            "quality_label",
+            "qualityName",
+            "video_quality",
+            "source_quality",
+            "hd"
+        };
+
+        private static readonly string[] MovieVoiceQueryKeys =
+        {
+            "voice",
+            "translate",
+            "translation",
+            "t",
+            "translation_id",
+            "translationId",
+            "translation_key",
+            "translationKey",
+            "voice_id",
+            "voiceId"
+        };
+
+        private static readonly string[] MovieQualityQueryKeys =
+        {
+            "quality",
+            "maxquality",
+            "maxQuality",
+            "q"
+        };
+
+        public static MovieRenderPayload PrepareMoviePayload(JToken data, IReadOnlyDictionary<string, string> query, string host)
+        {
+            var items = ExtractMovieArray(data) ?? new JArray();
+            var filters = MovieFilterCriteria.From(query);
+
+            var voiceOptions = CollectVoiceOptions(items);
+            var qualityOptions = CollectQualityOptions(items);
+
+            string voiceFilterHtml = BuildMovieVoiceHtml(voiceOptions, filters, query, host);
+            string qualityFilterHtml = BuildMovieQualityHtml(qualityOptions, filters, query, host);
+
+            var filteredItems = ApplyMovieFilters(items, filters);
+
+            return new MovieRenderPayload(filteredItems, CombineFilterHtml(voiceFilterHtml, qualityFilterHtml), filters?.HasFilters ?? false);
+        }
+
+        private static JArray ExtractMovieArray(JToken data)
+        {
+            if (data is JArray array)
+                return array;
+
+            if (data is JObject obj)
+            {
+                foreach (var key in new[] { "data", "results", "items" })
+                {
+                    if (obj.TryGetValue(key, out var token) && token is JArray nested)
+                        return nested;
+                }
+            }
+
+            return null;
+        }
+
+        private static string CombineFilterHtml(string first, string second)
+        {
+            if (string.IsNullOrEmpty(first))
+                return string.IsNullOrEmpty(second) ? null : second;
+
+            if (string.IsNullOrEmpty(second))
+                return first;
+
+            return first + second;
+        }
+
+        private static string BuildMovieVoiceHtml(List<MovieVoiceOption> options, MovieFilterCriteria filters, IReadOnlyDictionary<string, string> query, string host)
+        {
+            if (options == null || options.Count == 0)
+                return null;
+
+            var tpl = new VoiceTpl(options.Count + 1);
+
+            string resetLink = BuildMovieFilterLink(query, host, null, filters?.Quality);
+            tpl.Append("Все озвучки", filters == null || string.IsNullOrEmpty(filters.Voice), resetLink);
+
+            foreach (var option in options)
+            {
+                string value = string.IsNullOrWhiteSpace(option.Value) ? option.Label : option.Value;
+                string link = BuildMovieFilterLink(query, host, value, filters?.Quality);
+                bool active = filters?.IsVoiceActive(option) ?? false;
+                tpl.Append(option.Label, active, link);
+            }
+
+            return tpl.ToHtml();
+        }
+
+        private static string BuildMovieQualityHtml(List<MovieQualityOption> options, MovieFilterCriteria filters, IReadOnlyDictionary<string, string> query, string host)
+        {
+            if (options == null || options.Count == 0)
+                return null;
+
+            var tpl = new VoiceTpl(options.Count + 1);
+
+            string resetLink = BuildMovieFilterLink(query, host, filters?.Voice, null);
+            tpl.Append("Все качества", filters == null || string.IsNullOrEmpty(filters.Quality), resetLink);
+
+            foreach (var option in options)
+            {
+                string link = BuildMovieFilterLink(query, host, filters?.Voice, option.Value);
+                bool active = filters?.IsQualityActive(option) ?? false;
+                tpl.Append(option.Value, active, link);
+            }
+
+            return tpl.ToHtml();
+        }
+
+        private static string BuildMovieFilterLink(IReadOnlyDictionary<string, string> baseQuery, string host, string voice, string quality)
+        {
+            var query = new Dictionary<string, string>(baseQuery ?? new Dictionary<string, string>(), StringComparer.OrdinalIgnoreCase);
+
+            ApplyQueryValue(query, voice, MovieVoiceQueryKeys);
+            ApplyQueryValue(query, quality, MovieQualityQueryKeys);
+
+            string baseUrl = string.IsNullOrWhiteSpace(host) ? "/lite/smartfilter" : $"{host.TrimEnd('/')}/lite/smartfilter";
+
+            return QueryHelpers.AddQueryString(baseUrl, query);
+        }
+
+        private static void ApplyQueryValue(Dictionary<string, string> query, string value, params string[] keys)
+        {
+            foreach (var key in keys ?? Array.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    query.Remove(key);
+                else
+                    query[key] = value.Trim();
+            }
+        }
+
+        private static List<MovieVoiceOption> CollectVoiceOptions(JArray items)
+        {
+            var result = new Dictionary<string, MovieVoiceOption>(StringComparer.OrdinalIgnoreCase);
+
+            if (items != null)
+            {
+                foreach (var obj in items.OfType<JObject>())
+                {
+                    string label = ExtractVoiceLabel(obj);
+                    string provider = obj.Value<string>("provider") ?? obj.Value<string>("balanser");
+
+                    if (string.IsNullOrWhiteSpace(label))
+                    {
+                        if (string.IsNullOrWhiteSpace(provider))
+                            continue;
+
+                        label = provider;
+                    }
+
+                    string value = ExtractVoiceValue(obj);
+                    if (string.IsNullOrWhiteSpace(value))
+                        value = label;
+
+                    string key = string.IsNullOrWhiteSpace(value) ? NormalizeVoiceKey(label) : value;
+
+                    if (!result.TryGetValue(key, out var option))
+                    {
+                        option = new MovieVoiceOption(label, value);
+                        result[key] = option;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(provider))
+                        option.Providers.Add(provider);
+                }
+            }
+
+            EnsureUniqueVoiceLabels(result.Values);
+
+            return result.Values
+                .OrderBy(o => o.Label, StringComparer.CurrentCultureIgnoreCase)
+                .ToList();
+        }
+
+        private static void EnsureUniqueVoiceLabels(IEnumerable<MovieVoiceOption> options)
+        {
+            if (options == null)
+                return;
+
+            var duplicates = options
+                .Where(o => !string.IsNullOrWhiteSpace(o.Label))
+                .GroupBy(o => o.NormalizedLabel, StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1)
+                .ToList();
+
+            foreach (var group in duplicates)
+            {
+                foreach (var option in group)
+                {
+                    string provider = option.Providers.FirstOrDefault(p => !string.IsNullOrWhiteSpace(p));
+                    if (!string.IsNullOrWhiteSpace(provider))
+                        option.AppendProvider(provider);
+                }
+            }
+        }
+
+        private static string ExtractVoiceLabel(JObject obj)
+        {
+            if (obj == null)
+                return null;
+
+            foreach (var key in new[] { "translate", "voice", "voice_name", "voiceName", "translation", "dub" })
+            {
+                var value = obj.Value<string>(key);
+                if (!string.IsNullOrWhiteSpace(value))
+                    return value.Trim();
+            }
+
+            return null;
+        }
+
+        private static string ExtractVoiceValue(JObject obj)
+        {
+            if (obj == null)
+                return null;
+
+            foreach (var key in new[] { "translation_key", "translationKey", "translation_id", "translationId", "voice_id", "voiceId", "voice", "t" })
+            {
+                var value = obj.Value<string>(key);
+                if (!string.IsNullOrWhiteSpace(value))
+                    return value.Trim();
+            }
+
+            return null;
+        }
+
+        private static List<MovieQualityOption> CollectQualityOptions(JArray items)
+        {
+            var result = new Dictionary<string, MovieQualityOption>(StringComparer.OrdinalIgnoreCase);
+
+            if (items != null)
+            {
+                foreach (var obj in items.OfType<JObject>())
+                {
+                    foreach (var key in MovieQualityKeys)
+                    {
+                        var value = obj.Value<string>(key);
+                        if (string.IsNullOrWhiteSpace(value))
+                            continue;
+
+                        value = value.Trim();
+                        if (!result.ContainsKey(value))
+                            result[value] = new MovieQualityOption(value);
+                    }
+                }
+            }
+
+            return result.Values
+                .OrderByDescending(o => o.Rank)
+                .ThenBy(o => o.Value, StringComparer.CurrentCultureIgnoreCase)
+                .ToList();
+        }
+
+        private static JArray ApplyMovieFilters(JArray items, MovieFilterCriteria filters)
+        {
+            if (items == null)
+                return new JArray();
+
+            if (filters == null || !filters.HasFilters)
+                return items;
+
+            var filtered = new JArray();
+
+            foreach (var token in items)
+            {
+                if (token is not JObject obj)
+                {
+                    filtered.Add(token);
+                    continue;
+                }
+
+                if (!filters.MatchesVoice(obj))
+                    continue;
+
+                if (!filters.MatchesQuality(obj))
+                    continue;
+
+                filtered.Add(obj);
+            }
+
+            return filtered;
+        }
+
+        private sealed class MovieVoiceOption
+        {
+            public MovieVoiceOption(string label, string value)
+            {
+                Label = string.IsNullOrWhiteSpace(label) ? (value ?? string.Empty) : label.Trim();
+                Value = string.IsNullOrWhiteSpace(value) ? Label : value.Trim();
+                NormalizedValue = NormalizeVoiceKey(Value);
+                NormalizedLabel = NormalizeVoiceKey(Label);
+            }
+
+            public string Label { get; private set; }
+            public string Value { get; }
+            public string NormalizedValue { get; }
+            public string NormalizedLabel { get; private set; }
+            public HashSet<string> Providers { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            public void AppendProvider(string provider)
+            {
+                if (string.IsNullOrWhiteSpace(provider))
+                    return;
+
+                string formatted = provider.Trim();
+                if (string.IsNullOrWhiteSpace(formatted))
+                    return;
+
+                if (string.IsNullOrWhiteSpace(Label))
+                    Label = formatted;
+                else if (!Label.Contains(formatted, StringComparison.OrdinalIgnoreCase))
+                    Label = $"{Label} • {formatted}";
+
+                NormalizedLabel = NormalizeVoiceKey(Label);
+            }
+        }
+
+        private sealed class MovieQualityOption
+        {
+            public MovieQualityOption(string value)
+            {
+                Value = value ?? string.Empty;
+                Normalized = NormalizeQualityValue(Value);
+                Rank = GetQualityRank(Value);
+            }
+
+            public string Value { get; }
+            public string Normalized { get; }
+            public int Rank { get; }
+        }
+
+        private sealed class MovieFilterCriteria
+        {
+            private MovieFilterCriteria(string voice, string quality)
+            {
+                Voice = string.IsNullOrWhiteSpace(voice) ? null : voice.Trim();
+                Quality = string.IsNullOrWhiteSpace(quality) ? null : quality.Trim();
+                NormalizedVoice = NormalizeVoiceKey(Voice);
+                NormalizedQuality = NormalizeQualityValue(Quality);
+            }
+
+            public string Voice { get; }
+            public string Quality { get; }
+            public string NormalizedVoice { get; }
+            public string NormalizedQuality { get; }
+            public bool HasFilters => !string.IsNullOrEmpty(Voice) || !string.IsNullOrEmpty(Quality);
+
+            public static MovieFilterCriteria From(IReadOnlyDictionary<string, string> query)
+            {
+                if (query == null || query.Count == 0)
+                    return new MovieFilterCriteria(null, null);
+
+                string voice = GetFirst(query, MovieVoiceQueryKeys);
+                string quality = GetFirst(query, MovieQualityQueryKeys);
+
+                return new MovieFilterCriteria(voice, quality);
+            }
+
+            private static string GetFirst(IReadOnlyDictionary<string, string> query, params string[] keys)
+            {
+                foreach (var key in keys ?? Array.Empty<string>())
+                {
+                    if (query.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
+                        return value;
+                }
+
+                return null;
+            }
+
+            public bool MatchesVoice(JObject obj)
+            {
+                if (string.IsNullOrEmpty(Voice) || obj == null)
+                    return true;
+
+                foreach (var key in MovieVoiceKeys)
+                {
+                    var value = obj.Value<string>(key);
+                    if (string.IsNullOrWhiteSpace(value))
+                        continue;
+
+                    if (string.Equals(value, Voice, StringComparison.OrdinalIgnoreCase))
+                        return true;
+
+                    if (!string.IsNullOrEmpty(NormalizedVoice) && string.Equals(NormalizeVoiceKey(value), NormalizedVoice, StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+
+                return false;
+            }
+
+            public bool MatchesQuality(JObject obj)
+            {
+                if (string.IsNullOrEmpty(Quality) || obj == null)
+                    return true;
+
+                foreach (var key in MovieQualityKeys)
+                {
+                    var value = obj.Value<string>(key);
+                    if (string.IsNullOrWhiteSpace(value))
+                        continue;
+
+                    if (string.Equals(value, Quality, StringComparison.OrdinalIgnoreCase))
+                        return true;
+
+                    var normalized = NormalizeQualityValue(value);
+                    if (!string.IsNullOrEmpty(NormalizedQuality) && !string.IsNullOrEmpty(normalized)
+                        && normalized.Contains(NormalizedQuality, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public bool IsVoiceActive(MovieVoiceOption option)
+            {
+                if (option == null || string.IsNullOrEmpty(Voice))
+                    return false;
+
+                if (!string.IsNullOrWhiteSpace(option.Value) && string.Equals(option.Value, Voice, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                if (string.IsNullOrEmpty(NormalizedVoice))
+                    return false;
+
+                if (!string.IsNullOrEmpty(option.NormalizedValue) && string.Equals(option.NormalizedValue, NormalizedVoice, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                if (!string.IsNullOrEmpty(option.NormalizedLabel) && string.Equals(option.NormalizedLabel, NormalizedVoice, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                return false;
+            }
+
+            public bool IsQualityActive(MovieQualityOption option)
+            {
+                if (option == null || string.IsNullOrEmpty(Quality))
+                    return false;
+
+                if (string.Equals(option.Value, Quality, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                if (string.IsNullOrEmpty(NormalizedQuality))
+                    return false;
+
+                if (!string.IsNullOrEmpty(option.Normalized) && option.Normalized.Contains(NormalizedQuality, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                return false;
+            }
+        }
+
+        private static string NormalizeVoiceKey(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            string normalized = value.Trim().ToLowerInvariant();
+            normalized = Regex.Replace(normalized, @"\s+", " ");
+            return normalized;
+        }
+
+        private static string NormalizeQualityValue(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            string normalized = value.Trim().ToUpperInvariant();
+            normalized = Regex.Replace(normalized, @"\s+", string.Empty);
+            normalized = normalized.Replace("-", string.Empty).Replace("_", string.Empty);
+            return normalized;
+        }
+
+        private static int GetQualityRank(string quality)
+        {
+            if (string.IsNullOrWhiteSpace(quality))
+                return 0;
+
+            var match = Regex.Match(quality, @"(\d{3,4})p", RegexOptions.IgnoreCase);
+            if (match.Success && int.TryParse(match.Groups[1].Value, out int parsed))
+                return parsed;
+
+            if (quality.IndexOf("4K", StringComparison.OrdinalIgnoreCase) >= 0)
+                return 2160;
+
+            if (quality.IndexOf("1440", StringComparison.OrdinalIgnoreCase) >= 0)
+                return 1440;
+
+            if (quality.IndexOf("1080", StringComparison.OrdinalIgnoreCase) >= 0)
+                return 1080;
+
+            if (quality.IndexOf("720", StringComparison.OrdinalIgnoreCase) >= 0)
+                return 720;
+
+            if (quality.IndexOf("480", StringComparison.OrdinalIgnoreCase) >= 0)
+                return 480;
+
+            if (quality.IndexOf("360", StringComparison.OrdinalIgnoreCase) >= 0)
+                return 360;
+
+            return 0;
         }
 
         private static string BuildMovieHtml(JArray data, string title, string originalTitle)


### PR DESCRIPTION
## Summary
- добавлена подготовка серверных фильтров для фильмов (озвучки и качества) и генерация кнопок VoiceTpl
- реализована фильтрация данных SmartFilterController на основании выбранных параметров без потери HTML вывода

## Testing
- dotnet build *(не выполнено: в контейнере отсутствует dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ee9a03ed2c83318238eb9fccfbaa57