### PR TITLE
Handle subtitle parsing without SubtitleTpl.FromJson

### DIFF
--- a/SmartFilter/ModInit.cs
+++ b/SmartFilter/ModInit.cs
@@ -13,7 +13,7 @@ namespace SmartFilter
         private static int _configVersion = 0;
         public static int ConfigVersion => _configVersion;
 
-        private static FileSystemWatcher _fsw;
+        private static FileSystemWatcher? _fsw;
 
         public static void InvalidateCache() => Interlocked.Increment(ref _configVersion);
 


### PR DESCRIPTION
## Summary
- parse subtitle arrays manually when building episode templates
- adjust provider proxy tuple typing to avoid implicit-null compilation errors
- mark the module file watcher as nullable to silence constructor warnings

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eec2949880833187a890c9755de5dc