### PR TITLE
Add explicit HttpContext import to SmartFilter controller

### DIFF
--- a/SmartFilter/SmartFilterController.cs
+++ b/SmartFilter/SmartFilterController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;


### PR DESCRIPTION
## Summary
- add the missing Microsoft.AspNetCore.Http using directive to SmartFilterController to allow runtime compilation to resolve HttpContext

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eec9dbdb0c83319ad504617c0a4b54